### PR TITLE
Fix warnings requiring adding "type LT" in supertraits

### DIFF
--- a/src/library/scala/collection/IndexedSeqOptimized.scala
+++ b/src/library/scala/collection/IndexedSeqOptimized.scala
@@ -23,6 +23,8 @@ import scala.annotation.tailrec
  */
 trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { self =>
 
+  type LT
+
   override /*IterableLike*/
   def isEmpty: Boolean = { length == 0 }
 
@@ -278,4 +280,3 @@ trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { 
       super.endsWith(that)
   }
 }
-

--- a/src/library/scala/collection/Iterable.scala
+++ b/src/library/scala/collection/Iterable.scala
@@ -21,6 +21,8 @@ trait Iterable[+A] extends Traversable[A]
                       with GenIterable[A]
                       with GenericTraversableTemplate[A, Iterable]
                       with IterableLike[A, Iterable[A]] {
+  type LT
+
   override def companion: GenericCompanion[Iterable] = Iterable
 
   override def seq = this

--- a/src/library/scala/collection/IterableLike.scala
+++ b/src/library/scala/collection/IterableLike.scala
@@ -51,6 +51,8 @@ import scala.annotation.unchecked.uncheckedVariance
 trait IterableLike[+A, +Repr] extends Any with Equals with TraversableLike[A, Repr] with GenIterableLike[A, Repr] {
 self =>
 
+  type LT
+
   override protected[this] def thisCollection: Iterable[A] = this.asInstanceOf[Iterable[A]]
   override protected[this] def toCollection(repr: Repr): Iterable[A] = repr.asInstanceOf[Iterable[A]]
 
@@ -83,8 +85,8 @@ self =>
     iterator.foldRight(z)(op)
   override /*TraversableLike*/ def reduceRight[B >: A](op: (A, B) => B): B =
     iterator.reduceRight(op)
-    
-  
+
+
   /** Returns this $coll as an iterable collection.
    *
    *  A new collection will not be built; lazy collections will stay lazy.
@@ -94,7 +96,7 @@ self =>
    */
   override /*TraversableLike*/ def toIterable: Iterable[A] =
     thisCollection
-  
+
   /** Returns an Iterator over the elements in this $coll.  Produces the same
    *  result as `iterator`.
    *  $willNotTerminateInf
@@ -102,7 +104,7 @@ self =>
    */
   @deprecatedOverriding("toIterator should stay consistent with iterator for all Iterables: override iterator instead.", "2.11.0")
   override def toIterator: Iterator[A] = iterator
-  
+
   override /*TraversableLike*/ def head: A =
     iterator.next()
 

--- a/src/library/scala/collection/Iterator.scala
+++ b/src/library/scala/collection/Iterator.scala
@@ -265,6 +265,8 @@ import Iterator.empty
 trait Iterator[+A] extends TraversableOnce[A] {
   self =>
 
+  type LT
+
   def seq: Iterator[A] = this
 
   /** Tests whether this iterator can provide another element.

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -34,6 +34,8 @@ import scala.annotation.tailrec
  */
 trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends LinearSeqLike[A, Repr] { self: Repr =>
 
+  type LT
+
   def isEmpty: Boolean
 
   def head: A

--- a/src/library/scala/collection/MapLike.scala
+++ b/src/library/scala/collection/MapLike.scala
@@ -63,6 +63,8 @@ trait MapLike[A, +B, +This <: MapLike[A, B, This] with Map[A, B]]
 {
 self =>
 
+  type LT
+
   /** The empty map of the same type as this map
    *   @return   an empty map of type `This`.
    */

--- a/src/library/scala/collection/Traversable.scala
+++ b/src/library/scala/collection/Traversable.scala
@@ -22,6 +22,8 @@ trait Traversable[+A] extends TraversableLike[A, Traversable[A]]
                          with GenTraversable[A]
                          with TraversableOnce[A]
                          with GenericTraversableTemplate[A, Traversable] {
+  type LT
+
   override def companion: GenericCompanion[Traversable] = Traversable
 
   override def seq: Traversable[A] = this

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -26,6 +26,8 @@ import scala.reflect.ClassTag
  */
 @deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
 trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversable[A]] extends TraversableLike[A, Repr] with Proxy {
+  type LT
+
   def self: Repr
 
   override def foreach[B](f: A => B): Unit = self.foreach(f)

--- a/src/library/scala/collection/TraversableViewLike.scala
+++ b/src/library/scala/collection/TraversableViewLike.scala
@@ -74,6 +74,8 @@ trait TraversableViewLike[+A,
 {
   self =>
 
+  type LT
+
   protected def underlying: Coll
   protected[this] def viewIdentifier: String = ""
   protected[this] def viewIdString: String = ""

--- a/src/library/scala/collection/generic/GenericTraversableTemplate.scala
+++ b/src/library/scala/collection/generic/GenericTraversableTemplate.scala
@@ -28,6 +28,7 @@ import scala.language.higherKinds
  *  @define Coll  Traversable
  */
 trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNewBuilder[A, CC[A] @uncheckedVariance] {
+  type LT
 
   /** Applies a function `f` to all elements of this $coll.
    *
@@ -229,4 +230,3 @@ trait GenericTraversableTemplate[+A, +CC[X] <: GenTraversable[X]] extends HasNew
     bb.result()
   }
 }
-

--- a/src/library/scala/collection/generic/TraversableForwarder.scala
+++ b/src/library/scala/collection/generic/TraversableForwarder.scala
@@ -29,6 +29,8 @@ import scala.reflect.ClassTag
  */
 @deprecated("Forwarding is inherently unreliable since it is not automated and new methods can be forgotten.", "2.11.0")
 trait TraversableForwarder[+A] extends Traversable[A] {
+  type LT
+
   /** The traversable object to which calls are forwarded. */
   protected def underlying: Traversable[A]
 

--- a/src/library/scala/collection/parallel/RemainsIterator.scala
+++ b/src/library/scala/collection/parallel/RemainsIterator.scala
@@ -38,6 +38,8 @@ private[collection] trait RemainsIterator[+T] extends Iterator[T] {
  */
 private[collection] trait AugmentedIterableIterator[+T] extends RemainsIterator[T] {
 
+  type LT
+
   /* accessors */
 
   override def count(@plocal p: T => Boolean): Int = {
@@ -282,6 +284,8 @@ private[collection] trait AugmentedIterableIterator[+T] extends RemainsIterator[
 
 
 private[collection] trait AugmentedSeqIterator[+T] extends AugmentedIterableIterator[T] {
+
+  type LT
 
   /** The exact number of elements this iterator has yet to iterate.
    *  This method doesn't change the state of the iterator.


### PR DESCRIPTION
Some cases were tricky to fix; I isolated them in separate commits (i.e., last 2 commits) so we can investigate it more closely later.
