### PR TITLE
Cut number of errors almost in half

### DIFF
--- a/src/library/scala/collection/GenSeqLike.scala
+++ b/src/library/scala/collection/GenSeqLike.scala
@@ -31,6 +31,8 @@ import generic._
  *  Unlike iterables, sequences always have a defined order of elements.
  */
 trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equals with Parallelizable[A, parallel.ParSeq[A]] {
+  type LT
+
   def seq: Seq[A]
 
   /** Selects an element by its index in the $coll.
@@ -80,7 +82,7 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *  @return  the length of the longest segment of this $coll starting from index `from`
    *           such that every element of the segment satisfies the predicate `p`.
    */
-  def segmentLength(p: A => Boolean, from: Int): Int
+  def segmentLength(@plocal p: A => Boolean, from: Int): Int
 
   /** Returns the length of the longest prefix whose elements all satisfy some predicate.
    *
@@ -90,7 +92,7 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *  @return  the length of the longest prefix of this $coll
    *           such that every element of the segment satisfies the predicate `p`.
    */
-  def prefixLength(p: A => Boolean): Int = segmentLength(p, 0)
+  def prefixLength(@plocal p: A => Boolean): Int = segmentLength(p, 0)
 
   /** Finds index of the first element satisfying some predicate after or at some start index.
    *
@@ -338,10 +340,10 @@ trait GenSeqLike[+A, +Repr] extends Any with GenIterableLike[A, Repr] with Equal
    *    {{{
    *       scala> val a = List(1)
    *       a: List[Int] = List(1)
-   *       
+   *
    *       scala> val b = a :+ 2
    *       b: List[Int] = List(1, 2)
-   *       
+   *
    *       scala> println(a)
    *       List(1)
    *    }}}

--- a/src/library/scala/collection/GenTraversableOnce.scala
+++ b/src/library/scala/collection/GenTraversableOnce.scala
@@ -396,7 +396,7 @@ trait GenTraversableOnce[+A] extends Any {
    */
   def minBy[B](@plocal f: A => B)(implicit cmp: Ordering[B]): A
 
-  def forall(pred: A => Boolean): Boolean
+  def forall(@plocal pred: A => Boolean): Boolean
 
   def exists(pred: A => Boolean): Boolean
 

--- a/src/library/scala/collection/IndexedSeqOptimized.scala
+++ b/src/library/scala/collection/IndexedSeqOptimized.scala
@@ -35,7 +35,7 @@ trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { 
     while (i < len) { f(this(i)); i += 1 }
   }
 
-  private def prefixLengthImpl(p: A => Boolean, expectTrue: Boolean): Int = {
+  private def prefixLengthImpl(@plocal p: A => Boolean, expectTrue: Boolean): Int = {
     var i = 0
     while (i < length && p(apply(i)) == expectTrue) i += 1
     i
@@ -191,7 +191,7 @@ trait IndexedSeqOptimized[+A, +Repr] extends Any with IndexedSeqLike[A, Repr] { 
   def lengthCompare(len: Int): Int = length - len
 
   override /*SeqLike*/
-  def segmentLength(p: A => Boolean, from: Int): Int = {
+  def segmentLength(@plocal p: A => Boolean, from: Int): Int = {
     val len = length
     var i = from
     while (i < len && p(this(i))) i += 1

--- a/src/library/scala/collection/IterableViewLike.scala
+++ b/src/library/scala/collection/IterableViewLike.scala
@@ -36,6 +36,8 @@ trait IterableViewLike[+A,
         with TraversableViewLike[A, Coll, This]
 { self =>
 
+  type LT
+
   /** Explicit instantiation of the `Transformed` trait to reduce class file size in subclasses. */
   private[collection] abstract class AbstractTransformed[+B] extends Iterable[B] with super[TraversableViewLike].Transformed[B] with Transformed[B]
 
@@ -112,10 +114,10 @@ trait IterableViewLike[+A,
   protected override def newAppended[B >: A](that: GenTraversable[B]): Transformed[B] = new { val rest = that } with AbstractTransformed[B] with Appended[B]
   protected override def newMapped[B](f: A => B): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with Mapped[B]
   protected override def newFlatMapped[B](f: A => GenTraversableOnce[B]): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with FlatMapped[B]
-  protected override def newFiltered(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
+  protected override def newFiltered(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
   protected override def newSliced(_endpoints: SliceInterval): Transformed[A] = new { val endpoints = _endpoints } with AbstractTransformed[A] with Sliced
-  protected override def newDroppedWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
-  protected override def newTakenWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
+  protected override def newDroppedWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
+  protected override def newTakenWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
 
   // After adding take and drop overrides to IterableLike, these overrides (which do nothing
   // but duplicate the implementation in TraversableViewLike) had to be added to prevent the

--- a/src/library/scala/collection/LinearSeqOptimized.scala
+++ b/src/library/scala/collection/LinearSeqOptimized.scala
@@ -283,7 +283,7 @@ trait LinearSeqOptimized[+A, +Repr <: LinearSeqOptimized[A, Repr]] extends Linea
   def isDefinedAt(x: Int): Boolean = x >= 0 && lengthCompare(x) > 0
 
   override /*SeqLike*/
-  def segmentLength(p: A => Boolean, from: Int): Int = {
+  def segmentLength(@plocal p: A => Boolean, from: Int): Int = {
     var i = 0
     var these = this drop from
     while (!these.isEmpty && p(these.head)) {

--- a/src/library/scala/collection/SeqLike.scala
+++ b/src/library/scala/collection/SeqLike.scala
@@ -61,6 +61,8 @@ import scala.math.{ min, max, Ordering }
  */
 trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[A, Repr] with Parallelizable[A, ParSeq[A]] { self =>
 
+  type LT
+
   override protected[this] def thisCollection: Seq[A] = this.asInstanceOf[Seq[A]]
   override protected[this] def toCollection(repr: Repr): Seq[A] = repr.asInstanceOf[Seq[A]]
 
@@ -105,7 +107,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    */
   override def size = length
 
-  def segmentLength(p: A => Boolean, from: Int): Int = {
+  def segmentLength(@plocal p: A => Boolean, from: Int): Int = {
     var i = 0
     val it = iterator.drop(from)
     while (it.hasNext && p(it.next()))
@@ -146,7 +148,7 @@ trait SeqLike[+A, +Repr] extends Any with IterableLike[A, Repr] with GenSeqLike[
    *  more than one way to generate the same subsequence, only one will be returned.
    *
    *  For example, `"xyyy"` has three different ways to generate `"xy"` depending on
-   *  whether the first, second, or third `"y"` is selected.  However, since all are 
+   *  whether the first, second, or third `"y"` is selected.  However, since all are
    *  identical, only one will be chosen.  Which of the three will be taken is an
    *  implementation detail that is not defined.
    *

--- a/src/library/scala/collection/SeqProxyLike.scala
+++ b/src/library/scala/collection/SeqProxyLike.scala
@@ -31,8 +31,8 @@ trait SeqProxyLike[+A, +Repr <: SeqLike[A, Repr] with Seq[A]] extends SeqLike[A,
   override def apply(idx: Int): A = self.apply(idx)
   override def lengthCompare(len: Int): Int = self.lengthCompare(len)
   override def isDefinedAt(x: Int): Boolean = self.isDefinedAt(x)
-  override def segmentLength(p: A => Boolean, from: Int): Int = self.segmentLength(p, from)
-  override def prefixLength(p: A => Boolean) = self.prefixLength(p)
+  override def segmentLength(@plocal p: A => Boolean, from: Int): Int = self.segmentLength(p, from)
+  override def prefixLength(@plocal p: A => Boolean) = self.prefixLength(p)
   override def indexWhere(p: A => Boolean): Int = self.indexWhere(p)
   override def indexWhere(p: A => Boolean, from: Int): Int = self.indexWhere(p, from)
   override def indexOf[B >: A](elem: B): Int = self.indexOf(elem)
@@ -70,5 +70,3 @@ trait SeqProxyLike[+A, +Repr <: SeqLike[A, Repr] with Seq[A]] extends SeqLike[A,
   override def view = self.view
   override def view(from: Int, until: Int) = self.view(from, until)
 }
-
-

--- a/src/library/scala/collection/SeqViewLike.scala
+++ b/src/library/scala/collection/SeqViewLike.scala
@@ -196,10 +196,10 @@ trait SeqViewLike[+A,
   protected override def newAppended[B >: A](that: GenTraversable[B]): Transformed[B] = new { val rest = that } with AbstractTransformed[B] with Appended[B]
   protected override def newMapped[B](f: A => B): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with Mapped[B]
   protected override def newFlatMapped[B](f: A => GenTraversableOnce[B]): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with FlatMapped[B]
-  protected override def newFiltered(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
+  protected override def newFiltered(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
   protected override def newSliced(_endpoints: SliceInterval): Transformed[A] = new { val endpoints = _endpoints } with AbstractTransformed[A] with Sliced
-  protected override def newDroppedWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
-  protected override def newTakenWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
+  protected override def newDroppedWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
+  protected override def newTakenWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
   protected override def newZipped[B](that: GenIterable[B]): Transformed[(A, B)] = new { val other = that } with AbstractTransformed[(A, B)] with Zipped[B]
   protected override def newZippedAll[A1 >: A, B](that: GenIterable[B], _thisElem: A1, _thatElem: B): Transformed[(A1, B)] = new {
     val other = that

--- a/src/library/scala/collection/TraversableProxyLike.scala
+++ b/src/library/scala/collection/TraversableProxyLike.scala
@@ -25,8 +25,8 @@ import scala.reflect.ClassTag
  *  @since   2.8
  */
 @deprecated("Proxying is deprecated due to lack of use and compiler-level support.", "2.11.0")
-trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversable[A]] extends TraversableLike[A, Repr] with Proxy {
-  type LT
+trait TraversableProxyLike[+A, +Repr <: TraversableLike[A, Repr] with Traversable[A] /*{ type LT }*/] extends TraversableLike[A, Repr] with Proxy {
+  type LT //= Repr#LT
 
   def self: Repr
 

--- a/src/library/scala/collection/TraversableViewLike.scala
+++ b/src/library/scala/collection/TraversableViewLike.scala
@@ -257,10 +257,10 @@ trait TraversableViewLike[+A,
   protected def newAppended[B >: A](that: GenTraversable[B]): Transformed[B] = new { val rest = that } with AbstractTransformed[B] with Appended[B]
   protected def newMapped[B](f: A => B): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with Mapped[B]
   protected def newFlatMapped[B](f: A => GenTraversableOnce[B]): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with FlatMapped[B]
-  protected def newFiltered(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
+  protected def newFiltered(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
   protected def newSliced(_endpoints: SliceInterval): Transformed[A] = new { val endpoints = _endpoints } with AbstractTransformed[A] with Sliced
-  protected def newDroppedWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
-  protected def newTakenWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
+  protected def newDroppedWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
+  protected def newTakenWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
 
   protected def newTaken(n: Int): Transformed[A] = newSliced(SliceInterval(0, n))
   protected def newDropped(n: Int): Transformed[A] = newSliced(SliceInterval(n, Int.MaxValue))

--- a/src/library/scala/collection/generic/SeqForwarder.scala
+++ b/src/library/scala/collection/generic/SeqForwarder.scala
@@ -34,8 +34,8 @@ trait SeqForwarder[+A] extends Seq[A] with IterableForwarder[A] {
   override def apply(idx: Int): A = underlying.apply(idx)
   override def lengthCompare(len: Int): Int = underlying lengthCompare len
   override def isDefinedAt(x: Int): Boolean = underlying isDefinedAt x
-  override def segmentLength(p: A => Boolean, from: Int): Int = underlying.segmentLength(p, from)
-  override def prefixLength(p: A => Boolean) = underlying prefixLength p
+  override def segmentLength(@plocal p: A => Boolean, from: Int): Int = underlying.segmentLength(p, from)
+  override def prefixLength(@plocal p: A => Boolean) = underlying prefixLength p
   override def indexWhere(p: A => Boolean): Int = underlying indexWhere p
   override def indexWhere(p: A => Boolean, from: Int): Int = underlying.indexWhere(p, from)
   override def indexOf[B >: A](elem: B): Int = underlying indexOf elem

--- a/src/library/scala/collection/immutable/HashMap.scala
+++ b/src/library/scala/collection/immutable/HashMap.scala
@@ -42,6 +42,8 @@ class HashMap[A, +B] extends AbstractMap[A, B]
 {
   import HashMap.{nullToEmpty, bufferSize}
 
+  type LT
+
   override def size: Int = 0
 
   override def empty = HashMap.empty[A, B]
@@ -75,7 +77,7 @@ class HashMap[A, +B] extends AbstractMap[A, B]
     nullToEmpty(filter0(p, true, 0, buffer, 0))
   }
 
-  protected def filter0(p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] = null
+  protected def filter0(@plocal p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] = null
 
   protected def elemHashCode(key: A) = key.##
 
@@ -214,7 +216,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
     override def removed0(key: A, hash: Int, level: Int): HashMap[A, B] =
       if (hash == this.hash && key == this.key) HashMap.empty[A,B] else this
 
-    override protected def filter0(p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] =
+    override protected def filter0(@plocal p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] =
       if (negate ^ p(ensurePair)) this else null
 
     override def iterator: Iterator[(A,B)] = Iterator(ensurePair)
@@ -260,7 +262,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
         }
       } else this
 
-    override protected def filter0(p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] = {
+    override protected def filter0(@plocal p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] = {
       val kvs1 = if(negate) kvs.filterNot(p) else kvs.filter(p)
       kvs1.size match {
         case 0 =>
@@ -372,7 +374,7 @@ object HashMap extends ImmutableMapFactory[HashMap] with BitOperations.Int {
       }
     }
 
-    override protected def filter0(p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] = {
+    override protected def filter0(@plocal p: ((A, B)) => Boolean, negate: Boolean, level: Int, buffer: Array[HashMap[A, B @uV]], offset0: Int): HashMap[A, B] = {
       // current offset
       var offset = offset0
       // result size

--- a/src/library/scala/collection/immutable/HashSet.scala
+++ b/src/library/scala/collection/immutable/HashSet.scala
@@ -163,7 +163,7 @@ class HashSet[A] extends AbstractSet[A]
     nullToEmpty(removed0(e, computeHash(e), 0))
 
   /** Returns this $coll as an immutable set.
-   *  
+   *
    *  A new set will not be built; lazy collections will stay lazy.
    */
   @deprecatedOverriding("Immutable sets should do nothing on toSet but return themselves cast as a Set.", "2.11.0")
@@ -179,7 +179,7 @@ class HashSet[A] extends AbstractSet[A]
     nullToEmpty(filter0(p, true, 0, buffer, 0))
   }
 
-  protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = null
+  protected def filter0(@plocal p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = null
 
   protected def elemHashCode(key: A) = key.##
 
@@ -221,7 +221,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
 
   private object EmptyHashSet extends HashSet[Any] { }
   private[collection] def emptyInstance: HashSet[Any] = EmptyHashSet
-  
+
   // utility method to create a HashTrieSet from two leaf HashSets (HashSet1 or HashSetCollision1) with non-colliding hash code)
   private def makeHashTrieSet[A](hash0:Int, elem0:HashSet[A], hash1:Int, elem1:HashSet[A], level:Int) : HashTrieSet[A] = {
     val index0 = (hash0 >>> level) & 0x1f
@@ -315,7 +315,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
     override def removed0(key: A, hash: Int, level: Int): HashSet[A] =
       if (hash == this.hash && key == this.key) null else this
 
-    override protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] =
+    override protected def filter0(@plocal p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] =
       if (negate ^ p(key)) this else null
 
     override def iterator: Iterator[A] = Iterator(key)
@@ -450,7 +450,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         }
       } else this
 
-    override protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
+    override protected def filter0(@plocal p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
       val ks1 = if(negate) ks.filterNot(p) else ks.filter(p)
       ks1.size match {
         case 0 =>
@@ -922,7 +922,7 @@ object HashSet extends ImmutableSetFactory[HashSet] {
         false
     }
 
-    override protected def filter0(p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
+    override protected def filter0(@plocal p: A => Boolean, negate: Boolean, level: Int, buffer: Array[HashSet[A]], offset0: Int): HashSet[A] = {
       // current offset
       var offset = offset0
       // result size
@@ -1053,4 +1053,3 @@ object HashSet extends ImmutableSetFactory[HashSet] {
   }
 
 }
-

--- a/src/library/scala/collection/immutable/Range.scala
+++ b/src/library/scala/collection/immutable/Range.scala
@@ -33,7 +33,7 @@ import scala.collection.parallel.immutable.ParRange
  *  `init`) are also permitted on overfull ranges.
  *
  *  @param start      the start of this range.
- *  @param end        the end of the range.  For exclusive ranges, e.g. 
+ *  @param end        the end of the range.  For exclusive ranges, e.g.
  *                    `Range(0,3)` or `(0 until 3)`, this is one
  *                    step past the last one in the range.  For inclusive
  *                    ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
@@ -92,7 +92,7 @@ extends scala.collection.AbstractSeq[Int]
     }
   }
   @deprecated("This method will be made private, use `last` instead.", "2.11")
-  final val lastElement = 
+  final val lastElement =
     if (isEmpty) start - step
     else step match {
       case 1  => if (isInclusive) end else end-1
@@ -103,7 +103,7 @@ extends scala.collection.AbstractSeq[Int]
         else if (isInclusive) end
         else end - step
     }
-    
+
   @deprecated("This method will be made private.", "2.11")
   final val terminalElement = lastElement + step
 
@@ -230,7 +230,7 @@ extends scala.collection.AbstractSeq[Int]
   }
 
   // Advance from the start while we meet the given test
-  private def argTakeWhile(p: Int => Boolean): Long = {
+  private def argTakeWhile(@plocal p: Int => Boolean): Long = {
     if (isEmpty) start
     else {
       var current = start

--- a/src/library/scala/collection/immutable/Stream.scala
+++ b/src/library/scala/collection/immutable/Stream.scala
@@ -176,9 +176,9 @@ import scala.language.implicitConversions
  *    loop(1, 1)
  *  }
  *  }}}
- * 
+ *
  *  Note that `mkString` forces evaluation of a `Stream`, but `addString` does
- *  not.  In both cases, a `Stream` that is or ends in a cycle 
+ *  not.  In both cases, a `Stream` that is or ends in a cycle
  *  (e.g. `lazy val s: Stream[Int] = 0 #:: s`) will convert additional trips
  *  through the cycle to `...`.  Additionally, `addString` will display an
  *  un-memoized tail as `?`.
@@ -205,6 +205,8 @@ abstract class Stream[+A] extends AbstractSeq[A]
                              with LinearSeqOptimized[A, Stream[A]]
                              with Serializable {
 self =>
+  override type LT = Nothing
+
   override def companion: GenericCompanion[Stream] = Stream
 
   import scala.collection.{Traversable, Iterable, Seq, IndexedSeq}
@@ -1303,5 +1305,3 @@ object Stream extends SeqFactory[Stream] {
     cons(head, stream.tail.collect(pf)(bf).asInstanceOf[Stream[B]])
   }
 }
-
-

--- a/src/library/scala/collection/immutable/StreamViewLike.scala
+++ b/src/library/scala/collection/immutable/StreamViewLike.scala
@@ -55,10 +55,10 @@ extends SeqView[A, Coll]
   protected override def newAppended[B >: A](that: scala.collection.GenTraversable[B]): Transformed[B] = new { val rest = that } with AbstractTransformed[B] with Appended[B]
   protected override def newMapped[B](f: A => B): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with Mapped[B]
   protected override def newFlatMapped[B](f: A => scala.collection.GenTraversableOnce[B]): Transformed[B] = new { val mapping = f } with AbstractTransformed[B] with FlatMapped[B]
-  protected override def newFiltered(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
+  protected override def newFiltered(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
   protected override def newSliced(_endpoints: SliceInterval): Transformed[A] = new { val endpoints = _endpoints } with AbstractTransformed[A] with Sliced
-  protected override def newDroppedWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
-  protected override def newTakenWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
+  protected override def newDroppedWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
+  protected override def newTakenWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
   protected override def newZipped[B](that: scala.collection.GenIterable[B]): Transformed[(A, B)] = new { val other = that } with AbstractTransformed[(A, B)] with Zipped[B]
   protected override def newZippedAll[A1 >: A, B](that: scala.collection.GenIterable[B], _thisElem: A1, _thatElem: B): Transformed[(A1, B)] = {
     new { val other = that; val thisElem = _thisElem; val thatElem = _thatElem } with AbstractTransformed[(A1, B)] with ZippedAll[A1, B]

--- a/src/library/scala/collection/immutable/TreeMap.scala
+++ b/src/library/scala/collection/immutable/TreeMap.scala
@@ -105,7 +105,7 @@ class TreeMap[A, +B] private (tree: RB.Tree[A, B])(implicit val ordering: Orderi
   override def takeRight(n: Int) = drop(size - math.max(n, 0))
   override def splitAt(n: Int) = (take(n), drop(n))
 
-  private[this] def countWhile(p: ((A, B)) => Boolean): Int = {
+  private[this] def countWhile(@plocal p: ((A, B)) => Boolean): Int = {
     var result = 0
     val it = iterator
     while (it.hasNext && p(it.next())) result += 1

--- a/src/library/scala/collection/immutable/TreeSet.scala
+++ b/src/library/scala/collection/immutable/TreeSet.scala
@@ -91,7 +91,7 @@ class TreeSet[A] private (tree: RB.Tree[A, Unit])(implicit val ordering: Orderin
   override def takeRight(n: Int) = drop(size - math.max(n, 0))
   override def splitAt(n: Int) = (take(n), drop(n))
 
-  private[this] def countWhile(p: A => Boolean): Int = {
+  private[this] def countWhile(@plocal p: A => Boolean): Int = {
     var result = 0
     val it = iterator
     while (it.hasNext && p(it.next())) result += 1

--- a/src/library/scala/collection/mutable/IndexedSeqView.scala
+++ b/src/library/scala/collection/mutable/IndexedSeqView.scala
@@ -77,10 +77,10 @@ self =>
   /** Boilerplate method, to override in each subclass
    *  This method could be eliminated if Scala had virtual classes
    */
-  protected override def newFiltered(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
+  protected override def newFiltered(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
   protected override def newSliced(_endpoints: SliceInterval): Transformed[A] = new { val endpoints = _endpoints } with AbstractTransformed[A] with Sliced
-  protected override def newDroppedWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
-  protected override def newTakenWhile(p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
+  protected override def newDroppedWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with DroppedWhile
+  protected override def newTakenWhile(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with TakenWhile
   protected override def newReversed: Transformed[A] = new AbstractTransformed[A] with Reversed
 
   override def filter(@plocal p: A => Boolean): This = newFiltered(p)

--- a/src/library/scala/collection/parallel/ParIterableLike.scala
+++ b/src/library/scala/collection/parallel/ParIterableLike.scala
@@ -523,7 +523,7 @@ self: ParIterableLike[T, Repr, Sequential] =>
    *  @param pred    a predicate used to test elements
    *  @return        true if `p` holds for all elements, false otherwise
    */
-  def forall(pred: T => Boolean): Boolean = {
+  def forall(@plocal pred: T => Boolean): Boolean = {
     tasksupport.executeAndWaitResult(new Forall(pred, splitter assign new DefaultSignalling with VolatileAbort))
   }
 

--- a/src/library/scala/collection/parallel/ParSeqLike.scala
+++ b/src/library/scala/collection/parallel/ParSeqLike.scala
@@ -104,7 +104,7 @@ self =>
    *  @return      the length of the longest segment of elements starting at `from` and
    *               satisfying the predicate
    */
-  def segmentLength(p: T => Boolean, from: Int): Int = if (from >= length) 0 else {
+  def segmentLength(@plocal p: T => Boolean, from: Int): Int = if (from >= length) 0 else {
     val realfrom = if (from < 0) 0 else from
     val ctx = new DefaultSignalling with AtomicIndexFlag
     ctx.setIndexFlag(Int.MaxValue)

--- a/src/library/scala/collection/parallel/RemainsIterator.scala
+++ b/src/library/scala/collection/parallel/RemainsIterator.scala
@@ -294,7 +294,7 @@ private[collection] trait AugmentedSeqIterator[+T] extends AugmentedIterableIter
 
   /* accessors */
 
-  def prefixLength(pred: T => Boolean): Int = {
+  def prefixLength(@plocal pred: T => Boolean): Int = {
     var total = 0
     var loop = true
     while (hasNext && loop) {

--- a/src/library/scala/collection/parallel/Tasks.scala
+++ b/src/library/scala/collection/parallel/Tasks.scala
@@ -526,7 +526,7 @@ private[parallel] final class FutureTasks(executor: ExecutionContext) extends Ta
 }
 
 /** This tasks implementation uses execution contexts to spawn a parallel computation.
- *  
+ *
  *  As an optimization, it internally checks whether the execution context is the
  *  standard implementation based on fork/join pools, and if it is, creates a
  *  `ForkJoinTaskSupport` that shares the same pool to forward its request to it.
@@ -540,7 +540,7 @@ trait ExecutionContextTasks extends Tasks {
   val environment: ExecutionContext
 
   /** A driver serves as a target for this proxy `Tasks` object.
-   *  
+   *
    *  If the execution context has the standard implementation and uses fork/join pools,
    *  the driver is `ForkJoinTaskSupport` with the same pool, as an optimization.
    *  Otherwise, the driver will be a Scala `Future`-based implementation.

--- a/src/library/scala/collection/parallel/mutable/ParArray.scala
+++ b/src/library/scala/collection/parallel/mutable/ParArray.scala
@@ -151,7 +151,7 @@ self =>
       c
     }
 
-    private def count_quick(p: T => Boolean, a: Array[Any], ntil: Int, from: Int) = {
+    private def count_quick(@plocal p: T => Boolean, a: Array[Any], ntil: Int, from: Int) = {
       var cnt = 0
       var j = from
       while (j < ntil) {
@@ -233,7 +233,7 @@ self =>
     }
 
     // it's faster to use a separate small method
-    private def forall_quick(p: T => Boolean, a: Array[Any], nextuntil: Int, start: Int): Boolean = {
+    private def forall_quick(@plocal p: T => Boolean, a: Array[Any], nextuntil: Int, start: Int): Boolean = {
       var j = start
       while (j < nextuntil) {
         if (p(a(j).asInstanceOf[T])) j += 1
@@ -261,7 +261,7 @@ self =>
     }
 
     // faster to use separate small method
-    private def exists_quick(p: T => Boolean, a: Array[Any], nextuntil: Int, start: Int): Boolean = {
+    private def exists_quick(@plocal p: T => Boolean, a: Array[Any], nextuntil: Int, start: Int): Boolean = {
       var j = start
       while (j < nextuntil) {
         if (p(a(j).asInstanceOf[T])) return true
@@ -289,7 +289,7 @@ self =>
       r
     }
 
-    private def find_quick(p: T => Boolean, a: Array[Any], nextuntil: Int, start: Int): Option[T] = {
+    private def find_quick(@plocal p: T => Boolean, a: Array[Any], nextuntil: Int, start: Int): Option[T] = {
       var j = start
       while (j < nextuntil) {
         val elem = a(j).asInstanceOf[T]
@@ -310,13 +310,13 @@ self =>
       i += totallen
     }
 
-    override def prefixLength(pred: T => Boolean): Int = {
+    override def prefixLength(@plocal pred: T => Boolean): Int = {
       val r = prefixLength_quick(pred, arr, until, i)
       i += r + 1
       r
     }
 
-    private def prefixLength_quick(pred: T => Boolean, a: Array[Any], ntil: Int, startpos: Int): Int = {
+    private def prefixLength_quick(@plocal pred: T => Boolean, a: Array[Any], ntil: Int, startpos: Int): Int = {
       var j = startpos
       var endpos = ntil
       while (j < endpos) {
@@ -333,7 +333,7 @@ self =>
       ret
     }
 
-    private def indexWhere_quick(pred: T => Boolean, a: Array[Any], ntil: Int, from: Int): Int = {
+    private def indexWhere_quick(@plocal pred: T => Boolean, a: Array[Any], ntil: Int, from: Int): Int = {
       var j = from
       var pos = -1
       while (j < ntil) {


### PR DESCRIPTION
Reduced the number of errors from cca 100 to 60. Here is the categorization of representative errors left:
# "value ... cannot be used inside value $anonfun"

```
[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/Enumeration.scala:168: error: value cc cannot be used inside value $anonfun
[quick.library]       val value = ESC.THROW(m.invoke(this).asInstanceOf[Value])(cc)
[quick.library]                                                                 ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/IndexedSeqOptimized.scala:52: error: value p cannot be used inside value $anonfun
[quick.library]     val i = prefixLength(!p(_))
[quick.library]                           ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/MapLike.scala:320: error: value p cannot be used inside value $anonfun
[quick.library]       if (p(kv)) res = (res - kv._1).asInstanceOf[This] // !!! concrete overrides abstract problem
[quick.library]           ^
```
# "value ... cannot be used as 1st class value ..."
## Call on `super`

```
[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/IndexedSeqOptimized.scala:76: error: value op cannot be used as 1st class value @local[TraversableOnce.this.LT]
[quick.library]     if (length > 0) foldl(1, length, this(0), op) else super.reduceLeft(op)
[quick.library]                                                                         ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/immutable/List.scala:288: error: value f cannot be used as 1st class value @local[TraversableLike.this.LT]
[quick.library]     else super.map(f)
[quick.library]                    ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/IndexedSeqOptimized.scala:155: error: value p cannot be used as 1st class value @local[GenSeqLike.this.LT]
[quick.library]   def takeWhile(@plocal p: A => Boolean): Repr = take(prefixLength(p))
[quick.library]                                                                    ^
```
## Call on Inner class instance
### of similar type (modulo *Like)

```
[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/IterableLike.scala:77: error: value p cannot be used as 1st class value @local[Iterator.this.LT]
[quick.library]     iterator.forall(p)
[quick.library]                     ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/generic/SeqForwarder.scala:38: error: value p cannot be used as 1st class value @local[GenSeqLike.this.LT]
[quick.library]   override def prefixLength(@plocal p: A => Boolean) = underlying prefixLength p
[quick.library]                                                                                ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/generic/TraversableForwarder.scala:42: error: value p cannot be used as 1st class value @local[TraversableLike.this.LT]
[quick.library]   override def forall(@plocal p: A => Boolean): Boolean = underlying forall p
[quick.library]                                                                             ^
```
### of type argument (proxy)

```
[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/TraversableProxyLike.scala:46: error: value p cannot be used as 1st class value @local[TraversableLike.this.LT]
[quick.library]   override def forall(@plocal p: A => Boolean): Boolean = self.forall(p)
[quick.library]                                                                       ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/SeqProxyLike.scala:35: error: value p cannot be used as 1st class value @local[GenSeqLike.this.LT]
[quick.library]   override def prefixLength(@plocal p: A => Boolean) = self.prefixLength(p)
[quick.library]                                                                          ^
```
### of unrelated type

```
[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/immutable/HashMap.scala:387: error: value p cannot be used as 1st class value @local[HashMap.this.LT]
[quick.library]         val result = elems(i).filter0(p, negate, level + 5, buffer, offset)
[quick.library]                                       ^
```
## Passing @local function as ctor argument

```
[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/parallel/ParIterableLike.scala:527: error: value pred cannot be used as 1st class value @local[Nothing]
[quick.library]     tasksupport.executeAndWaitResult(new Forall(pred, splitter assign new DefaultSignalling with VolatileAbort))
[quick.library]                                                 ^
```
# "some @local annotation on arguments have been dropped"

```
[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/mutable/IndexedSeqView.scala:80: error: overriding method newFiltered in trait SeqViewLike with method newFiltered in trait IndexedSeqView:
[quick.library] some @local annotations on arguments have been dropped
[quick.library] member: IndexedSeqView.this.LT parent: SeqViewLike.this.LT
[quick.library]   protected override def newFiltered(@plocal p: A => Boolean): Transformed[A] = new { val pred = p } with AbstractTransformed[A] with Filtered
[quick.library]                          ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/generic/SeqForwarder.scala:38: error: overriding method prefixLength in trait GenSeqLike with method prefixLength in trait SeqForwarder:
[quick.library] some @local annotations on arguments have been dropped
[quick.library] member: SeqForwarder.this.LT parent: GenSeqLike.this.LT
[quick.library]   override def prefixLength(@plocal p: A => Boolean) = underlying prefixLength p
[quick.library]                ^

[quick.library] /home/losvald/usr/src-contrib/scala/src/library/scala/collection/immutable/Stream.scala:575: error: overriding method withFilter in class WithFilter with method withFilter in class StreamWithFilter:
[quick.library] some @local annotations on arguments have been dropped
[quick.library] member: Stream.this.LT parent: TraversableLike.this.LT
[quick.library]     override def withFilter(@plocal q: A => Boolean): StreamWithFilter =
[quick.library]                  ^
```
